### PR TITLE
local report generation failure

### DIFF
--- a/engine/src/main/java/com/testlum/testing/framework/report/extentreports/ExtentReportsConfigurator.java
+++ b/engine/src/main/java/com/testlum/testing/framework/report/extentreports/ExtentReportsConfigurator.java
@@ -51,7 +51,7 @@ public class ExtentReportsConfigurator {
         String reportPath = buildReportPath(projectName);
         try {
             ExtentSparkReporter sparkReporter = new ExtentSparkReporter(reportPath);
-            if (globalTestConfiguration.getReport().getExtentReports().isOnlyFailedScenarios()) {
+            if (Boolean.TRUE.equals(globalTestConfiguration.getReport().getExtentReports().isOnlyFailedScenarios())) {
                 sparkReporter.filter()
                         .statusFilter()
                         .as(new Status[]{Status.FAIL})


### PR DESCRIPTION
Fix NPE when isOnlyFailedScenarios absent in report section of global config