### PR TITLE
Fix HTTP endpoint variable resolution with leading slash

### DIFF
--- a/engine/src/main/resources/schema/shared.xsd
+++ b/engine/src/main/resources/schema/shared.xsd
@@ -143,7 +143,7 @@
     <x:simpleType name="endpointPattern">
         <x:restriction base="x:string">
             <x:minLength value="2"/>
-            <x:pattern value="(/[^/].+)"/>
+            <x:pattern value="(/[^/].+)|(\{\{.+\}\})"/>
         </x:restriction>
     </x:simpleType>
 

--- a/engine/src/test/java/com/testlum/testing/framework/xml/EndpointPatternTest.java
+++ b/engine/src/test/java/com/testlum/testing/framework/xml/EndpointPatternTest.java
@@ -1,0 +1,43 @@
+package com.testlum.testing.framework.xml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class EndpointPatternTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void acceptsEndpointContainingOnlyVariable() throws IOException {
+        String scenario = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <scenario xmlns="http://www.testlum.com/testing/model/scenario">
+                    <overview>
+                        <name>Endpoint variable test</name>
+                        <description>Verify endpoint variable schema validation</description>
+                    </overview>
+                    <settings/>
+                    <http comment="Call resource endpoint">
+                        <get endpoint="{{resourceEndpoint}}">
+                            <response code="200"/>
+                        </get>
+                    </http>
+                </scenario>
+                """;
+
+        Path scenarioFile = tempDir.resolve("scenario.xml");
+        Files.writeString(scenarioFile, scenario);
+
+        XMLParsers parsers = new XMLParsers();
+
+        assertDoesNotThrow(() ->
+                parsers.forScenario().process(scenarioFile.toFile()));
+    }
+}

--- a/modules/http/src/main/java/com/testlum/testing/framework/interpreter/HttpInterpreter.java
+++ b/modules/http/src/main/java/com/testlum/testing/framework/interpreter/HttpInterpreter.java
@@ -165,7 +165,9 @@ public class HttpInterpreter extends AbstractInterpreter<Http> {
     private String createFullUrl(final String endpoint, final String alias) {
         List<Api> apiList = integrationsProvider.findListByEnv(Api.class, dependencies.getEnvironment());
         Api apiIntegration = integrationsProvider.findApiForAlias(apiList, alias);
-        return apiIntegration.getUrl() + endpoint;
+        String baseUrl = StringUtils.stripEnd(apiIntegration.getUrl(), "/");
+        String normalizedEndpoint = "/" + StringUtils.stripStart(endpoint, "/");
+        return baseUrl + normalizedEndpoint;
     }
 
     private void logHttpInfo(final String alias, final String method, final String endpoint) {

--- a/modules/http/src/test/java/com/testlum/testing/framework/interpreter/HttpInterpreterTest.java
+++ b/modules/http/src/test/java/com/testlum/testing/framework/interpreter/HttpInterpreterTest.java
@@ -10,17 +10,21 @@ import com.testlum.testing.framework.util.ConditionProvider;
 import com.testlum.testing.framework.util.IntegrationsProvider;
 import com.testlum.testing.framework.util.JacksonService;
 import com.testlum.testing.framework.util.StringPrettifier;
+import com.testlum.testing.model.global_config.Api;
 import com.testlum.testing.model.global_config.GlobalTestConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.context.ApplicationContext;
 
 import java.io.File;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -30,12 +34,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+
 class HttpInterpreterTest {
 
     @TempDir
     File tempDir;
 
     private HttpInterpreter interpreter;
+    private IntegrationsProvider integrationsProvider;
 
     @BeforeEach
     void setUp() {
@@ -45,7 +51,8 @@ class HttpInterpreterTest {
         when(applicationContext.getBean(FileSearcher.class)).thenReturn(mock(FileSearcher.class));
         when(applicationContext.getBean(JacksonService.class)).thenReturn(mock(JacksonService.class));
         when(applicationContext.getBean(StringPrettifier.class)).thenReturn(mock(StringPrettifier.class));
-        when(applicationContext.getBean(IntegrationsProvider.class)).thenReturn(mock(IntegrationsProvider.class));
+        integrationsProvider = mock(IntegrationsProvider.class);
+        when(applicationContext.getBean(IntegrationsProvider.class)).thenReturn(integrationsProvider);
         when(applicationContext.getBean(HttpUtil.class)).thenReturn(mock(HttpUtil.class));
         final GlobalTestConfiguration globalConfig = mock(GlobalTestConfiguration.class);
         when(globalConfig.isStopScenarioOnFailure()).thenReturn(false);
@@ -103,6 +110,36 @@ class HttpInterpreterTest {
             assertEquals("alias", result.getMetadata().get("API alias"));
             assertEquals("POST", result.getMetadata().get("HTTP method"));
             assertTrue(result.getMetadata().containsKey("Additional headers"));
+        }
+    }
+
+    @Nested
+    class CreateFullUrl {
+
+        @ParameterizedTest
+        @CsvSource({
+                "https://example.com, api/test, https://example.com/api/test",
+                "https://example.com, /api/test, https://example.com/api/test",
+                "https://example.com, //api/test, https://example.com/api/test",
+                "https://example.com/, /api/test, https://example.com/api/test"
+        })
+        void normalizesSlashes(final String baseUrl,
+                               final String endpoint,
+                               final String expected) throws Exception {
+            Api api = new Api();
+            api.setUrl(baseUrl);
+            List<Api> integrations = List.of(api);
+
+            when(integrationsProvider.findListByEnv(Api.class, "test")).thenReturn(integrations);
+            when(integrationsProvider.findApiForAlias(integrations, "alias")).thenReturn(api);
+
+            Method method = HttpInterpreter.class.getDeclaredMethod(
+                    "createFullUrl", String.class, String.class);
+            method.setAccessible(true);
+
+            String actual = (String) method.invoke(interpreter, endpoint, "alias");
+
+            assertEquals(expected, actual);
         }
     }
 }


### PR DESCRIPTION
## What this changes

- Allows HTTP endpoints to be provided entirely through scenario variables.
- Normalizes slashes between the API base URL and the resolved endpoint.
- Adds regression tests for endpoint schema validation and URL construction.

## Why

An endpoint such as `{{resourceEndpoint}}` failed when the resolved value contained a leading slash. Both the base URL and endpoint are now normalized so variable-based endpoints work consistently.

## Testing

- `HttpInterpreterTest`: 7 tests passed
- `EndpointPatternTest`: 1 test passed

Closes #108